### PR TITLE
Update README.md with linux build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Process: TODO
 
 ### On Linux:
 
-(Tested on Ubuntu 16.04 i386)
+(Tested on Ubuntu 16.04 i386 and Linux Mint 18 "Sarah" - Cinnamon (64-bit))
 
 1. Install Bitmonero dependencies.
 
@@ -94,7 +94,13 @@ Process: TODO
 
 5. Install the GUI dependencies.
 
+  a) For Ubuntu 16.04 i386
+
 `sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs`
+
+  b) For Linux Mint 18 "Sarah" - Cinnamon (64-bit)
+
+`sudo apt install qml-module-qt-labs-settings qml-module-qtgraphicaleffects`
 
 6. Build the GUI.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,42 @@ Process: TODO
 
 
 ### On Linux:
-TODO
+
+(Tested on Ubuntu 16.04 i386)
+
+1. Install Bitmonero dependencies.
+
+`sudo apt install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev`
+
+2. Go to the repository where the most recent version is.
+
+`git clone https://github.com/mbg033/monero-core.git`
+
+3. Go into the repository.
+
+`cd monero-core`
+
+4. Use the script to compile the bitmonero libs necessary to run the GUI.
+
+`./get_libwallet_api.sh`
+
+5. Install the GUI dependencies.
+
+`sudo apt-get install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs`
+
+6. Build the GUI.
+
+`qmake`
+
+`make`
+
+7. Before running the GUI, it's recommended you have a copy of bitmonero running in the background.
+
+`./bitmonerod --rpc-bind-port 38081`
+
+8. Run the GUI client.
+
+`./release/bin/monero-core`
 
 ### On OS X:
 1. install homebrew


### PR DESCRIPTION
Tested and confirmed to work on Ubuntu 16.04 i386 on virtual machine. x64 version has build dependency issues however, an issue has been filed, see https://github.com/mbg033/monero-core/issues/40