### PR TITLE
make splash less resource intensive

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -52,7 +52,7 @@ ApplicationWindow {
     property var currentWallet;
     property var transaction;
     property alias password : passwordDialog.password
-
+    property int splashCounter: 0
 
     function altKeyReleased() { ctrlPressed = false; }
 
@@ -225,9 +225,13 @@ ApplicationWindow {
 
     function onWalletNewBlock(blockHeight) {
         if (splash.visible) {
-            var progressText = qsTr("Synchronizing blocks %1/%2").arg(blockHeight.toFixed(0)).arg(currentWallet.daemonBlockChainHeight().toFixed(0));
-            console.log("Progress text: " + progressText);
-            splash.heightProgressText = progressText
+            var currHeight = blockHeight.toFixed(0)
+            if(currHeight > splashCounter + 1000){
+              splashCounter = currHeight
+              var progressText = qsTr("Synchronizing blocks %1/%2").arg(currHeight).arg(currentWallet.daemonBlockChainHeight().toFixed(0));
+              console.log("Progress text: " + progressText);
+              splash.heightProgressText = progressText
+            }
         }
     }
 


### PR DESCRIPTION
Hi!

The progress splash is very cpu intensive. Made a small fix. Wallet syncs in less than 10 seconds now with your latest api updates on my macbook air. Great work!
