### PR TITLE
UX improvements in wizard

### DIFF
--- a/wizard/WizardPassword.qml
+++ b/wizard/WizardPassword.qml
@@ -52,6 +52,8 @@ Item {
         } else {
            passwordPage.titleText = qsTr("Now that your wallet has been restored, please set a password for the wallet") + translationManager.emptyString
         }
+
+        passwordItem.focus = true;
     }
 
     function onPageClosed(settingsObject) {
@@ -146,28 +148,32 @@ Item {
         anchors.topMargin: 24
         width: 300
         height: 62
+        placeholderText : qsTr("Password") + translationManager.emptyString;
+        KeyNavigation.tab: retypePasswordItem
         onChanged: handlePassword()
+
     }
 
+    WizardPasswordInput {
+        id: retypePasswordItem
+        anchors.top: passwordItem.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 24
+        width: 300
+        height: 62
+        placeholderText : qsTr("Confirm password") + translationManager.emptyString;
+        KeyNavigation.tab: passwordItem
+        onChanged: handlePassword()
+    }
 
     PrivacyLevelSmall {
         id: privacyLevel
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.top: passwordItem.bottom
-        anchors.topMargin: 24
+        anchors.top: retypePasswordItem.bottom
+        anchors.topMargin: 60
         background: "#F0EEEE"
         interactive: false
-    }
-
-    WizardPasswordInput {
-        id: retypePasswordItem
-        anchors.top: privacyLevel.bottom
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 24
-        width: 300
-        height: 62
-        onChanged: handlePassword()
     }
 
     Component.onCompleted: {

--- a/wizard/WizardPasswordInput.qml
+++ b/wizard/WizardPasswordInput.qml
@@ -27,24 +27,34 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import QtQuick 2.0
+import QtQuick.Controls 1.4
+import QtQuick.Controls.Styles 1.4
 
-Item {
+FocusScope {
     property alias password: password.text
+    property alias placeholderText: password.placeholderText
     signal changed(string password)
 
 
-    TextInput {
+    TextField {
         id : password
+        focus:true
         anchors.fill: parent
-        horizontalAlignment: TextInput.AlignHCenter
+        horizontalAlignment: TextInput.AlignLeft
         verticalAlignment: TextInput.AlignVCenter
         font.family: "Arial"
         font.pixelSize: 32
-        renderType: Text.NativeRendering
-        color: "#35B05A"
-        passwordCharacter: "•"
         echoMode: TextInput.Password
-        focus: true
+        style: TextFieldStyle {
+            renderType: Text.NativeRendering
+            textColor: "#35B05A"
+            passwordCharacter: "•"
+            background: Rectangle {
+                radius: 0
+                border.width: 0
+            }
+        }
+
         Keys.onReleased: {
             changed(text)
         }

--- a/wizard/WizardWelcome.qml
+++ b/wizard/WizardWelcome.qml
@@ -151,6 +151,7 @@ Item {
                     if (data !== null || data !== undefined) {
                         var locale = data.locale
                         translationManager.setLanguage(locale.split("_")[0]);
+                        wizard.switchPage(true)
                     }
                 }
             }


### PR DESCRIPTION
Fixes some UX issues reported in https://github.com/mbg033/monero-core/issues/34
- Password page: Added placeholder text, rearranged fields. (see attached image)
- Password page: tab navigation / focus field on page load
- Welcome page: Click on language loads next page (same behavior as create/recover wallet page)

![monero_wizard](https://cloud.githubusercontent.com/assets/5909557/19024062/69243476-88fc-11e6-8b31-1c7867581563.png)
