### PR TITLE
added onPageCompleted

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -43,6 +43,11 @@ Rectangle {
     onCurrentViewChanged: {
         if (currentView) {
             stackView.replace(currentView)
+
+            // Component.onCompleted is called before wallet is initilized
+            if (typeof currentView.onPageCompleted === "function") {
+                currentView.onPageCompleted();
+            }
         }
     }
 

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2015, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -49,6 +49,7 @@ Rectangle {
             addressLine.text = appWindow.currentWallet.address
             integratedAddressLine.text = appWindow.currentWallet.integratedAddress(payment_id)
         }
+
         paymentIdLine.text = payment_id
     }
 
@@ -175,9 +176,13 @@ Rectangle {
 
     }
 
-    Component.onCompleted: {
+    function onPageCompleted() {
         console.log("Receive page loaded");
-        updatePaymentId()
+
+        if(addressLine.text.length == 0) {
+            updatePaymentId()
+        }
+
     }
 
 }


### PR DESCRIPTION
Fixes issue where wallet adress did't get created because Component.onCompleted was called before wallet was loaded. 
