### PR TITLE
critical: store wallet after first successful refresh

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -54,6 +54,7 @@ ApplicationWindow {
     property var transaction;
     property alias password : passwordDialog.password
     property int splashCounter: 0
+    property bool isNewWallet: false
 
     function altKeyReleased() { ctrlPressed = false; }
 
@@ -142,6 +143,7 @@ ApplicationWindow {
         // wallet already opened with wizard, we just need to initialize it
         if (typeof wizard.settings['wallet'] !== 'undefined') {
             connectWallet(wizard.settings['wallet'])
+            isNewWallet = true
         }  else {
             var wallet_path = walletPath();
             // console.log("opening wallet at: ", wallet_path, "with password: ", appWindow.password);
@@ -218,6 +220,14 @@ ApplicationWindow {
         console.log(">>> wallet refreshed")
         if (splash.visible) {
             hideProcessingSplash()
+        }
+
+        // Store wallet after first refresh. To prevent broken wallet after a crash
+        // TODO: Move this to libwallet?
+        if(isNewWallet && currentWallet.blockChainHeight() > 0){
+            currentWallet.store(persistentSettings.wallet_path)
+            isNewWallet = false
+            console.log("wallet stored after first successfull refresh")
         }
 
         leftPanel.networkStatus.connected = currentWallet.connected


### PR DESCRIPTION
This fixes a critical bug that leaves the wallet in broken state in case of a crash (god forbid).
The bug only affects newly created wallets where wallet is synced, has transactions but isn't closed properly. When opening the crashed wallet the fast sync method will be used which will miss any transactions made from the wallet and therefore leaving it in broken state. 
Consider moving this logic to libwallet in future. 
